### PR TITLE
Allow users of cuipod to initialise with an X509Certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,5 @@ MigrationBackup/
 CuipodExample/Properties/launchSettings.json
 
 .vscode/
+.hg/
+.hgignore

--- a/Cuipod/App.cs
+++ b/Cuipod/App.cs
@@ -21,12 +21,22 @@ namespace Cuipod
 
         private RequestCallback _onBadRequestCallback;
 
+        //somewhat flaky implementation - probably deprecate it
         public App(string directoryToServe, string certificateFile, string privateRSAKeyFilePath)
         {
             _directoryToServe = directoryToServe;
             _listener = new TcpListener(IPAddress.Any, 1965);
             _requestCallbacks = new Dictionary<string, RequestCallback>();
             _serverCertificate = CertificateUtils.LoadCertificate(certificateFile, privateRSAKeyFilePath);
+        }
+
+        public App(string directoryToServe, X509Certificate2 certificate)
+        {
+
+            _directoryToServe = directoryToServe;
+            _listener = new TcpListener(IPAddress.Any, 1965);
+            _requestCallbacks = new Dictionary<string, RequestCallback>();
+            _serverCertificate = certificate;
         }
 
         public void OnRequest(string route, RequestCallback callback)

--- a/CuipodExample/Server.cs
+++ b/CuipodExample/Server.cs
@@ -31,21 +31,8 @@ namespace CuipodExample
                     return 1;
                 }
 
-                string pass;
-                if (pfxPassword != null)
-                {
-                    pass = pfxPassword.Value.ToString();
-                }
-                else
-                {
-                    pass = "";
-                }
-
-                Console.WriteLine("pass: " + pass.ToString());
-                Console.WriteLine("cert: " + certificateFile.Value.ToString());
-                
+                var pass = (pfxPassword != null)  ? pfxPassword.Value.ToString() : "";
                 var cert = new X509Certificate2(certificateFile.Value.ToString(), pass);
-
 
                 return AppMain(directoryToServe.Value, cert);
             });

--- a/CuipodExample/Server.cs
+++ b/CuipodExample/Server.cs
@@ -1,6 +1,7 @@
 ﻿using Cuipod;
 using Microsoft.Extensions.CommandLineUtils;
 using System;
+using System.Security.Cryptography.X509Certificates;
 
 namespace CuipodExample
 {
@@ -15,21 +16,38 @@ namespace CuipodExample
                 "Directory to server (required)"
             );
             CommandArgument certificateFile = commandLineApplication.Argument(
-                "certificate",
+                "pfx certificate file",
                 "Path to certificate (required)"
             );
-            CommandArgument privateRSAKeyFilePath = commandLineApplication.Argument(
-               "key",
-               "Path to private Pkcs8 RSA key (required)"
+            CommandArgument pfxPassword = commandLineApplication.Argument(
+               "pfx password",
+               "pfx password"
             );
             commandLineApplication.OnExecute(() =>
             {
-                if (directoryToServe.Value == null || certificateFile.Value == null || privateRSAKeyFilePath.Value == null)
+                if (directoryToServe.Value == null || certificateFile.Value == null )
                 {
                     commandLineApplication.ShowHelp();
                     return 1;
                 }
-                return AppMain(directoryToServe.Value, certificateFile.Value, privateRSAKeyFilePath.Value);
+
+                string pass;
+                if (pfxPassword != null)
+                {
+                    pass = pfxPassword.Value.ToString();
+                }
+                else
+                {
+                    pass = "";
+                }
+
+                Console.WriteLine("pass: " + pass.ToString());
+                Console.WriteLine("cert: " + certificateFile.Value.ToString());
+                
+                var cert = new X509Certificate2(certificateFile.Value.ToString(), pass);
+
+
+                return AppMain(directoryToServe.Value, cert);
             });
 
             try
@@ -42,12 +60,11 @@ namespace CuipodExample
             }
         }
 
-        private static int AppMain(string directoryToServe, string certificateFile, string privateRSAKeyFilePath)
+        private static int AppMain(string directoryToServe, X509Certificate2 certificate)
         {
             App app = new App(
                 directoryToServe,
-                certificateFile,
-                privateRSAKeyFilePath
+                certificate
             );
 
             // Serve files


### PR DESCRIPTION
cuipod at present is somewhat inflexible in that it expects to be initialised with an RSAkey which is only one of a range of ways of creating a certificate - and the implementation is a bit brittle (I couldnt get it to work for me!)

This pull request allows the server framework to be initialised with a passed in X509Certificate which the caller can create however it chooses, providing flexibility and more options